### PR TITLE
Removing unused step Setup Vault Cli from cd-dev.yaml

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -24,11 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Vault Cli
-        uses: innovationnorway/setup-vault@v1
-        with:
-          version: '~1.9.2'
-
       - name: Import DEVOPS Secrets
         uses: hashicorp/vault-action@v2.3.1
         with:


### PR DESCRIPTION
Se quita el step ya que no se utiliza la cli de vault en el job, siendo innecesario ejecutarlo.