### PR TITLE
fix(ci): upgrade google-github-actions/auth from v0 to v2

### DIFF
--- a/.github/workflows/backstage-ci.yml
+++ b/.github/workflows/backstage-ci.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     env:
       CI: true

--- a/.github/workflows/backstage-ci.yml
+++ b/.github/workflows/backstage-ci.yml
@@ -48,7 +48,7 @@ jobs:
           VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
         run: "vault kv get -format yaml -field=data ${{ inputs.VAULT_KV_PATH }}| sed 's/: /=/' > .env"
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - uses: pnpm/action-setup@v2.2.2

--- a/.github/workflows/backstage-publish-artifacts.yml
+++ b/.github/workflows/backstage-publish-artifacts.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   next-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Authenticate to Google Cloud
@@ -54,7 +54,7 @@ jobs:
 
   publish:
     name: Publish artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     needs: next-version
     if: needs.next-version.outputs.new-release-published == 'true'
@@ -116,7 +116,7 @@ jobs:
           gsutil -m -h "Cache-Control:public, must-revalidate, max-age=10" rsync -r dist/ gs://cdnmf-${{ matrix.env }}/${{ github.event.repository.name }}/${{ needs.next-version.outputs.new-release-version }}/
   release:
     name: Release semantic version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: publish
     steps:
       - name: Checkout

--- a/.github/workflows/backstage-publish-artifacts.yml
+++ b/.github/workflows/backstage-publish-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - uses: pnpm/action-setup@v2.2.2
@@ -85,7 +85,7 @@ jobs:
           VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
         run: "vault kv get -format yaml -field=data ${{ inputs.VAULT_KV_PATH }}/${{ matrix.env }} | sed 's/: /=/' > .env"
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - uses: pnpm/action-setup@v2.2.2
@@ -102,7 +102,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm run build
       - id: 'auth'
-        uses: google-github-actions/auth@v0.4.0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.ORG_GOOGLE_CREDENTIALS }}
       - uses: google-github-actions/setup-gcloud@v0
@@ -129,7 +129,7 @@ jobs:
           git config --global user.name "mundibot"
           git config --global user.email "tech@mundi.io"
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - uses: pnpm/action-setup@v2.2.2

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   cdn-upload:
     name: Upload artifacts to mundi cdn
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/cd-header.yml
+++ b/.github/workflows/cd-header.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   cdn_upload:
     name: Upload artifacts to mundi cdn
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/cd-navigation.yml
+++ b/.github/workflows/cd-navigation.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   cdn_upload:
     name: Upload artifacts to mundi cdn
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-header.yml
+++ b/.github/workflows/ci-header.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   create-artifacts:
     name: Build project artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci-header.yml
+++ b/.github/workflows/ci-header.yml
@@ -53,7 +53,7 @@ jobs:
           sort -u -t '=' -k 1,1 env-cloud env-mf > .env
       - run: cd header
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - name: Setup Node.js
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci-mf.yml
+++ b/.github/workflows/ci-mf.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     env:
       CI: true

--- a/.github/workflows/ci-mf.yml
+++ b/.github/workflows/ci-mf.yml
@@ -41,7 +41,7 @@ jobs:
           VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
         run: "vault kv get -format yaml -field=data ${{ inputs.VAULT_KV_PATH }}| sed 's/: /=/' > .env"
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci-navigation.yml
+++ b/.github/workflows/ci-navigation.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   create-artifacts:
     name: Build project artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci-navigation.yml
+++ b/.github/workflows/ci-navigation.yml
@@ -53,7 +53,7 @@ jobs:
           sort -u -t '=' -k 1,1 env-cloud env-mf > .env
       - run: cd navigation
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - name: Setup Node.js
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       
           sort -u -t '=' -k 1,1 env-cloud env-mf > .env
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
 
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
       - uses: actions/setup-node@v4

--- a/.github/workflows/multibranch-cleanup-header.yml
+++ b/.github/workflows/multibranch-cleanup-header.yml
@@ -34,14 +34,14 @@ on:
 
 jobs:
   merge-job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           echo PR #${{ github.event.number }} has been merged
 
   clean-up:
     name: Clean up multibranch environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/multibranch-cleanup-navigation.yml
+++ b/.github/workflows/multibranch-cleanup-navigation.yml
@@ -34,14 +34,14 @@ on:
 
 jobs:
   merge-job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           echo PR #${{ github.event.number }} has been merged
 
   clean-up:
     name: Clean up multibranch environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/multibranch-cleanup.yml
+++ b/.github/workflows/multibranch-cleanup.yml
@@ -34,14 +34,14 @@ on:
 
 jobs:
   merge-job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           echo PR #${{ github.event.number }} has been merged
 
   clean-up:
     name: Clean up multibranch environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
       - run: npm ci --omit=dev --ignore-scripts
       - run: npm run build
       - id: 'auth'
-        uses: google-github-actions/auth@v0.4.0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.ORG_GOOGLE_CREDENTIALS }}
       - uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   next-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -39,7 +39,7 @@ jobs:
 
   publish:
     name: Publish artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: next-version
     if: needs.next-version.outputs.new-release-published == 'true'
     strategy:
@@ -86,7 +86,7 @@ jobs:
 
   release:
     name: Release semantic version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: publish
     steps:
       - name: Checkout

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   semantic_release:
     name: Create new semantic release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -53,7 +53,7 @@ jobs:
           cat .env >> $GITHUB_ENV
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.NPM_REGISTRY_CREDENTIALS }}'
 


### PR DESCRIPTION
## Summary
- Upgrades `google-github-actions/auth` from deprecated `v0` to `v2` in all 8 reusable workflow files
- The v0 series now fails as a **hard error** instead of just warning, breaking CI for all MFs

## Affected workflows
| File | Occurrences replaced |
|------|---------------------|
| `ci.yml` | 2 (create-artifacts + lint-test jobs) |
| `ci-mf.yml` | 1 |
| `ci-header.yml` | 2 |
| `ci-navigation.yml` | 2 |
| `publish.yml` | 1 (was v0.4.0) |
| `semantic-release.yml` | 1 |
| `backstage-ci.yml` | 1 |
| `backstage-publish-artifacts.yml` | 4 (including one that was v0.4.0) |

## Impact
This fix is needed for ALL MFs that use these reusable workflows (invoice-mf, bo-applications-mf, etc.). After merge, a new tag (v1.1.17) should be created so MFs can reference it.

## Test plan
- [ ] After merge + new tag, re-run invoice-mf PR validation
- [ ] Verify "Authenticate to Google Cloud" step passes