### PR TITLE
fix(ci): pin ubuntu-24.04, reorder jobs, fix VPN/Vault silent failures

### DIFF
--- a/.github/workflows/backstage-ci.yml
+++ b/.github/workflows/backstage-ci.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
       CI: true

--- a/.github/workflows/backstage-publish-artifacts.yml
+++ b/.github/workflows/backstage-publish-artifacts.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   next-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Authenticate to Google Cloud
@@ -54,7 +54,7 @@ jobs:
 
   publish:
     name: Publish artifacts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: next-version
     if: needs.next-version.outputs.new-release-published == 'true'
@@ -116,7 +116,7 @@ jobs:
           gsutil -m -h "Cache-Control:public, must-revalidate, max-age=10" rsync -r dist/ gs://cdnmf-${{ matrix.env }}/${{ github.event.repository.name }}/${{ needs.next-version.outputs.new-release-version }}/
   release:
     name: Release semantic version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: publish
     steps:
       - name: Checkout

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   cdn-upload:
     name: Upload artifacts to mundi cdn
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/cd-header.yml
+++ b/.github/workflows/cd-header.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   cdn_upload:
     name: Upload artifacts to mundi cdn
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/cd-navigation.yml
+++ b/.github/workflows/cd-navigation.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   cdn_upload:
     name: Upload artifacts to mundi cdn
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   cdn_upload:
     name: Upload artifacts to mundi cdn
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/check-workflow-status.yml
+++ b/.github/workflows/check-workflow-status.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   validate_workflow_status:
     name: Upload artifacts to mundi cdn
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       status: ${{ steps.check-workflow.outputs.status }}
       conclusion: ${{ steps.check-workflow.outputs.conclusion }}

--- a/.github/workflows/check-workflow-status.yml
+++ b/.github/workflows/check-workflow-status.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   validate_workflow_status:
     name: Upload artifacts to mundi cdn
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       status: ${{ steps.check-workflow.outputs.status }}
       conclusion: ${{ steps.check-workflow.outputs.conclusion }}

--- a/.github/workflows/ci-header.yml
+++ b/.github/workflows/ci-header.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   create-artifacts:
     name: Build project artifacts
+    needs: lint-test
     runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -94,7 +95,11 @@ jobs:
       - name: Login to Artifact Registry
         run: npm run artifactregistry-login
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: |
+          npm config set fetch-retries 3
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm ci --ignore-scripts
 
       - run: npm test -- --passWithNoTests
 

--- a/.github/workflows/ci-header.yml
+++ b/.github/workflows/ci-header.yml
@@ -42,13 +42,25 @@ jobs:
         with:
           vpn_config: ${{ secrets.VPN_CONFIG }}
           vpn_pass: ${{ secrets.VPN_PASS }}
+      - name: Verify VPN connectivity
+        env:
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+        run: |
+          for i in 1 2 3; do
+            vault status && exit 0
+            echo "Retry $i..."
+            sleep 5
+          done
+          echo "VPN connectivity check failed"
+          exit 1
       - name: Vault Secrets to env
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
         run: |
+          set -eo pipefail
           export ENV_LOCAL=$(echo ${{ inputs.VAULT_KV_PATH }} | cut -d "/" -f 3)
-
           vault kv get -format yaml -field=data ${{ inputs.VAULT_KV_PATH }}| sed 's/: /=/' > env-mf
           vault kv get -format yaml -field=data cloud-infra-mf/$ENV_LOCAL| sed 's/: /=/' > env-cloud
           sort -u -t '=' -k 1,1 env-cloud env-mf > .env

--- a/.github/workflows/ci-header.yml
+++ b/.github/workflows/ci-header.yml
@@ -76,7 +76,7 @@ jobs:
 
   lint-test:
     name: Run linting rules and unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci-header.yml
+++ b/.github/workflows/ci-header.yml
@@ -26,7 +26,7 @@ jobs:
   create-artifacts:
     name: Build project artifacts
     needs: lint-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
 
   lint-test:
     name: Run linting rules and unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci-mf.yml
+++ b/.github/workflows/ci-mf.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
       CI: true

--- a/.github/workflows/ci-navigation.yml
+++ b/.github/workflows/ci-navigation.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   create-artifacts:
     name: Build project artifacts
+    needs: lint-test
     runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -94,7 +95,11 @@ jobs:
       - name: Login to Artifact Registry
         run: npm run artifactregistry-login
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: |
+          npm config set fetch-retries 3
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm ci --ignore-scripts
 
       - run: npm test -- --passWithNoTests
 

--- a/.github/workflows/ci-navigation.yml
+++ b/.github/workflows/ci-navigation.yml
@@ -42,13 +42,25 @@ jobs:
         with:
           vpn_config: ${{ secrets.VPN_CONFIG }}
           vpn_pass: ${{ secrets.VPN_PASS }}
+      - name: Verify VPN connectivity
+        env:
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+        run: |
+          for i in 1 2 3; do
+            vault status && exit 0
+            echo "Retry $i..."
+            sleep 5
+          done
+          echo "VPN connectivity check failed"
+          exit 1
       - name: Vault Secrets to env
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
         run: |
+          set -eo pipefail
           export ENV_LOCAL=$(echo ${{ inputs.VAULT_KV_PATH }} | cut -d "/" -f 3)
-
           vault kv get -format yaml -field=data ${{ inputs.VAULT_KV_PATH }}| sed 's/: /=/' > env-mf
           vault kv get -format yaml -field=data cloud-infra-mf/$ENV_LOCAL| sed 's/: /=/' > env-cloud
           sort -u -t '=' -k 1,1 env-cloud env-mf > .env

--- a/.github/workflows/ci-navigation.yml
+++ b/.github/workflows/ci-navigation.yml
@@ -76,7 +76,7 @@ jobs:
 
   lint-test:
     name: Run linting rules and unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci-navigation.yml
+++ b/.github/workflows/ci-navigation.yml
@@ -26,7 +26,7 @@ jobs:
   create-artifacts:
     name: Build project artifacts
     needs: lint-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
 
   lint-test:
     name: Run linting rules and unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,25 +42,27 @@ jobs:
         with:
           vpn_config: ${{ secrets.VPN_CONFIG }}
           vpn_pass: ${{ secrets.VPN_PASS }}
+      - name: Verify VPN connectivity
+        env:
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+        run: |
+          for i in 1 2 3; do
+            vault status && exit 0
+            echo "Retry $i..."
+            sleep 5
+          done
+          echo "VPN connectivity check failed"
+          exit 1
       - name: Vault Secrets to env
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
         run: |
+          set -eo pipefail
           export ENV_LOCAL=$(echo ${{ inputs.VAULT_KV_PATH }} | sed 's|.*/||')
-      
           vault kv get -format yaml -field=data ${{ inputs.VAULT_KV_PATH }} | sed 's/: /=/' > env-mf
-          if [ $? -ne 0 ]; then
-            echo "Failed to fetch secrets from ${{ inputs.VAULT_KV_PATH }}"
-            exit 1
-          fi
-      
           vault kv get -format yaml -field=data cloud-infra-mf/$ENV_LOCAL | sed 's/: /=/' > env-cloud
-          if [ $? -ne 0 ]; then
-            echo "Failed to fetch secrets from cloud-infra-mf/$ENV_LOCAL"
-            exit 1
-          fi
-      
           sort -u -t '=' -k 1,1 env-cloud env-mf > .env
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   create-artifacts:
     name: Build project artifacts
+    needs: lint-test
     runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -75,9 +76,6 @@ jobs:
       - name: Login to Artifact Registry
         run: npm run artifactregistry-login
 
-      - name: Clean cache 
-        run: npm cache clean --force
-      
       - name: Install dependencies
         run: npm ci --no-fund --ignore-scripts --legacy-peer-deps
 
@@ -109,11 +107,12 @@ jobs:
       - name: Login to Artifact Registry
         run: npm run artifactregistry-login
 
-      - name: Clean cache 
-        run: npm cache clean --force
-
       - name: Install dependencies
-        run: npm ci --no-fund --ignore-scripts --legacy-peer-deps
+        run: |
+          npm config set fetch-retries 3
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm ci --no-fund --ignore-scripts --legacy-peer-deps
 
       - run: npm test -- --passWithNoTests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
   lint-test:
     name: Run linting rules and unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   create-artifacts:
     name: Build project artifacts
     needs: lint-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
 
   lint-test:
     name: Run linting rules and unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/multibranch-cleanup-header.yml
+++ b/.github/workflows/multibranch-cleanup-header.yml
@@ -34,14 +34,14 @@ on:
 
 jobs:
   merge-job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - run: |
           echo PR #${{ github.event.number }} has been merged
 
   clean-up:
     name: Clean up multibranch environment
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/multibranch-cleanup-navigation.yml
+++ b/.github/workflows/multibranch-cleanup-navigation.yml
@@ -34,14 +34,14 @@ on:
 
 jobs:
   merge-job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - run: |
           echo PR #${{ github.event.number }} has been merged
 
   clean-up:
     name: Clean up multibranch environment
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/multibranch-cleanup.yml
+++ b/.github/workflows/multibranch-cleanup.yml
@@ -34,14 +34,14 @@ on:
 
 jobs:
   merge-job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - run: |
           echo PR #${{ github.event.number }} has been merged
 
   clean-up:
     name: Clean up multibranch environment
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   next-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -39,7 +39,7 @@ jobs:
 
   publish:
     name: Publish artifacts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: next-version
     if: needs.next-version.outputs.new-release-published == 'true'
     strategy:
@@ -86,7 +86,7 @@ jobs:
 
   release:
     name: Release semantic version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: publish
     steps:
       - name: Checkout

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   semantic_release:
     name: Create new semantic release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   sentry_release:
     name: Reusable workflow for sentry
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   sentry_release:
     name: Reusable workflow for sentry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Summary
- Pin all CI runners to `ubuntu-24.04` (latest LTS)
- Run `lint-test` first, `create-artifacts` depends on it (`needs: lint-test`) — fail fast + npm cache reuse
- Add npm fetch-retries config for transient ETIMEDOUT from Artifact Registry
- Remove `npm cache clean --force` that was defeating cache
- Add VPN connectivity verify step with 3 retries after VPN connect
- Add `set -eo pipefail` to Vault secrets step so pipe failures don't pass silently

## Test plan
- [x] Tested on credit-lines-mf PR #378 — all jobs passed